### PR TITLE
Configure server with express adapter

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,14 +8,17 @@
       "dependencies": {
         "@prisma/client": "^4.12.0",
         "@remix-run/css-bundle": "^1.17.0",
+        "@remix-run/express": "^1.17.0",
         "@remix-run/node": "^1.17.0",
         "@remix-run/react": "^1.17.0",
         "@remix-run/serve": "^1.17.0",
         "bcryptjs": "^2.4.3",
+        "express": "^4.18.2",
         "isbot": "^3.6.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "tiny-invariant": "^1.3.1"
+        "tiny-invariant": "^1.3.1",
+        "ws": "^8.13.0"
       },
       "devDependencies": {
         "@faker-js/faker": "^7.6.0",
@@ -2970,6 +2973,26 @@
       },
       "peerDependenciesMeta": {
         "@remix-run/serve": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@remix-run/dev/node_modules/ws": {
+      "version": "7.5.9",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
           "optional": true
         }
       }
@@ -15894,15 +15917,15 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "node_modules/ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q==",
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==",
       "engines": {
-        "node": ">=8.3.0"
+        "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -18062,6 +18085,13 @@
         "tsconfig-paths": "^4.0.0",
         "ws": "^7.4.5",
         "xdm": "^2.0.0"
+      },
+      "dependencies": {
+        "ws": {
+          "version": "7.5.9",
+          "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
+          "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
+        }
       }
     },
     "@remix-run/eslint-config": {
@@ -27501,9 +27531,9 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "ws": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.9.tgz",
-      "integrity": "sha512-F+P9Jil7UiSKSkppIiD94dN07AwvFixvLIj1Og1Rl9GGMuNipJnV9JzjD6XuqmAeiswGvUmNLjr5cFuXwNS77Q=="
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.13.0.tgz",
+      "integrity": "sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA=="
     },
     "xdm": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,9 @@
   "sideEffects": false,
   "scripts": {
     "build": "remix build",
-    "dev": "cross-env NODE_ENV=development binode --require ./mocks -- @remix-run/dev:remix dev",
+    "dev": "run-p dev:*",
+    "dev:remix": "NODE_ENV=development npx remix watch",
+    "dev:express": "NODE_ENV=development node ./server.js",
     "format": "prettier --write .",
     "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
     "setup": "prisma generate && prisma migrate deploy && prisma db seed",
@@ -26,14 +28,17 @@
   "dependencies": {
     "@prisma/client": "^4.12.0",
     "@remix-run/css-bundle": "^1.17.0",
+    "@remix-run/express": "^1.17.0",
     "@remix-run/node": "^1.17.0",
     "@remix-run/react": "^1.17.0",
     "@remix-run/serve": "^1.17.0",
     "bcryptjs": "^2.4.3",
+    "express": "^4.18.2",
     "isbot": "^3.6.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "tiny-invariant": "^1.3.1"
+    "tiny-invariant": "^1.3.1",
+    "ws": "^8.13.0"
   },
   "devDependencies": {
     "@faker-js/faker": "^7.6.0",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,14 @@
+const express = require("express");
+const remix = require("@remix-run/express");
+
+const app = express();
+
+app.use(express.static("public", { maxAge: "1h" }));
+
+app.all("*", remix.createRequestHandler({ build: require("./build") }));
+
+app.listen(process.env.PORT || 3000, () => {
+  console.log(
+    "Applciation running on http://localhost:" + (process.env.PORT || 3000)
+  );
+});


### PR DESCRIPTION
Implements https://github.com/bastilian/AAAPI/issues/14.

To test: `docker-compose up` or `npm run dev`, you should see all the endpoints available (working as they've been working) and console prints `Applciation running on http://localhost:3000` - the message from express `server.js`.